### PR TITLE
ci: set fail-fast on trivy scan matrix to false

### DIFF
--- a/.github/workflows/weekly-trivy-scan.yml
+++ b/.github/workflows/weekly-trivy-scan.yml
@@ -56,6 +56,7 @@ jobs:
     needs: generate-matrix
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false  # prevents canceling the others when one fails
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
     permissions:
       contents: read


### PR DESCRIPTION
This change makes that if one run of a part of the matrix fails the others can still continue to run and collect trivy results.